### PR TITLE
Creating context based handler for go 1.7

### DIFF
--- a/miniprofiler/context.go
+++ b/miniprofiler/context.go
@@ -1,0 +1,49 @@
+// +build go1.7
+
+package miniprofiler
+
+import (
+	"context"
+	"net/http"
+)
+
+// contextKey can be used to retreive the profiler instance from the request's context
+const contextKey = "MiniProfiler"
+
+// ContextHandler is an alternate handler that passes the profiler on the http request's context rather than as function arguments.
+// This approach is more compatible with standard net/http Handlers.
+type ContextHandler struct {
+	f http.HandlerFunc
+	p *Profile
+}
+
+// NewContextHandler creates a ContextHandler to wrap the given http.HandlerFunc. A profiler will be added to the request Context, and
+// can be retreived with miniprofiler.GetTimer(r)
+func NewContextHandler(f http.HandlerFunc) http.Handler {
+	return ContextHandler{
+		f: f,
+	}
+}
+
+func (h ContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Query().Get("pp") {
+	default:
+		h.profileRequest(w, r)
+	}
+}
+
+func (h ContextHandler) profileRequest(w http.ResponseWriter, r *http.Request) {
+	h.p = NewProfile(w, r, FuncName(h.f))
+	ctx := context.WithValue(r.Context(), contextKey, h.p)
+	h.f(w, r.WithContext(ctx))
+	h.p.Finalize()
+}
+
+// GetTimer will retreive the timer from the given http request's context. If the request has not been wrapped by a ContextHandler, nil will be returned.
+func GetTimer(r *http.Request) Timer {
+	val := r.Context().Value(contextKey)
+	if val == nil {
+		return nil
+	}
+	return val.(*Profile)
+}

--- a/miniprofiler/context.go
+++ b/miniprofiler/context.go
@@ -7,18 +7,21 @@ import (
 	"net/http"
 )
 
-// contextKey can be used to retreive the profiler instance from the request's context
-const contextKey = "MiniProfiler"
+type ctxKey string
 
-// ContextHandler is an alternate handler that passes the profiler on the http request's context rather than as function arguments.
+// contextKey can be used to retreive the profiler instance from the request's context
+const contextKey ctxKey = "miniprofiler"
+
+// ContextHandler is an alternate handler that passes the profiler on the http
+// request's context, rather than as function arguments.
 // This approach is more compatible with standard net/http Handlers.
 type ContextHandler struct {
 	f http.HandlerFunc
-	p *Profile
 }
 
-// NewContextHandler creates a ContextHandler to wrap the given http.HandlerFunc. A profiler will be added to the request Context, and
-// can be retreived with miniprofiler.GetTimer(r)
+// NewContextHandler creates a ContextHandler to wrap the given http.HandlerFunc.
+// A profiler will be added to the request Context, and can be retreived with
+// miniprofiler.GetTimer(r)
 func NewContextHandler(f http.HandlerFunc) http.Handler {
 	return ContextHandler{
 		f: f,
@@ -26,13 +29,14 @@ func NewContextHandler(f http.HandlerFunc) http.Handler {
 }
 
 func (h ContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	h.p = NewProfile(w, r, FuncName(h.f))
-	ctx := context.WithValue(r.Context(), contextKey, h.p)
+	p := NewProfile(w, r, FuncName(h.f))
+	ctx := context.WithValue(r.Context(), contextKey, p)
 	h.f(w, r.WithContext(ctx))
-	h.p.Finalize()
+	p.Finalize()
 }
 
-// GetTimer will retreive the timer from the given http request's context. If the request has not been wrapped by a ContextHandler, nil will be returned.
+// GetTimer will retreive the timer from the given http request's context.
+// If the request has not been wrapped by a ContextHandler, nil will be returned.
 func GetTimer(r *http.Request) Timer {
 	val := r.Context().Value(contextKey)
 	if val == nil {

--- a/miniprofiler/context.go
+++ b/miniprofiler/context.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 )
 
-type ctxKey string
+type ctxKey int
 
 // contextKey can be used to retreive the profiler instance from the request's context
-const contextKey ctxKey = "miniprofiler"
+const contextKey ctxKey = 0
 
 // ContextHandler is an alternate handler that passes the profiler on the http
 // request's context, rather than as function arguments.

--- a/miniprofiler/context.go
+++ b/miniprofiler/context.go
@@ -26,13 +26,6 @@ func NewContextHandler(f http.HandlerFunc) http.Handler {
 }
 
 func (h ContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.URL.Query().Get("pp") {
-	default:
-		h.profileRequest(w, r)
-	}
-}
-
-func (h ContextHandler) profileRequest(w http.ResponseWriter, r *http.Request) {
 	h.p = NewProfile(w, r, FuncName(h.f))
 	ctx := context.WithValue(r.Context(), contextKey, h.p)
 	h.f(w, r.WithContext(ctx))


### PR DESCRIPTION
Go 1.7 adds a context to `http.Request`. This adds a ContextHandler that uses the request context to pass a timer. This allows you to profile http handlers without modifying their signature.

Protected by build tags to only be availible in 1.7+. 